### PR TITLE
Feature/week1 user member

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,7 +11,10 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
     // querydsl
-    implementation("com.querydsl:querydsl-jpa::jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -12,12 +12,17 @@ import org.springframework.stereotype.Component;
 public class PointFacade {
     private final PointService pointService;
 
-    public PointInfo getPoint(String userId){
+    public PointInfo getPoint(String userId) {
         PointEntity point = pointService.getPointByUserId(userId);
 
         if (point == null) {
             throw new CoreException(ErrorType.BAD_REQUEST);
         }
+        return PointInfo.from(point);
+    }
+
+    public PointInfo chargePoint(PointInfo pointInfo) {
+        PointEntity point = pointService.chargePoint(pointInfo);
         return PointInfo.from(point);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -1,0 +1,23 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PointFacade {
+    private final PointService pointService;
+
+    public PointInfo getPoint(String userId){
+        PointEntity point = pointService.getPointByUserId(userId);
+
+        if (point == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST);
+        }
+        return PointInfo.from(point);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -1,9 +1,14 @@
 package com.loopers.application.point;
 
 import com.loopers.domain.point.PointEntity;
+import com.loopers.interfaces.api.point.PointV1Dto;
 
-public record PointInfo(Long point) {
+public record PointInfo(String userId, Long point) {
     public static PointInfo from(PointEntity point) {
-        return new PointInfo(point.getAmount());
+        return new PointInfo(point.getUserId(), point.getAmount());
+    }
+
+    public static PointInfo to(String userId, PointV1Dto.PointChargeRequest request) {
+        return new PointInfo(userId, request.point());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -1,0 +1,9 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointEntity;
+
+public record PointInfo(Long point) {
+    public static PointInfo from(PointEntity point) {
+        return new PointInfo(point.getAmount());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -2,6 +2,8 @@ package com.loopers.application.user;
 
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +18,9 @@ public class UserFacade {
 
     public UserInfo findByUserId(String userId){
         UserModel userModel = userService.findByUserId(userId);
+        if (userModel == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 ID 입니다.");
+        }
         return UserInfo.from(userModel);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,0 +1,22 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserFacade {
+    private final UserService userService;
+
+    public void signUp(UserInfo userInfo){
+        userService.signUp(UserInfo.to(userInfo));
+    }
+
+    public UserInfo findByUserId(String userId){
+        UserModel userModel = userService.findByUserId(userId);
+        return UserInfo.from(userModel);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,0 +1,23 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.UserModel;
+
+public record UserInfo(String userId, String email, String birthDate, String gender) {
+    public static UserModel to(UserInfo userInfo){
+        return new UserModel(
+                userInfo.userId(),
+                userInfo.email(),
+                userInfo.birthDate(),
+                userInfo.gender()
+        );
+    }
+
+    public static UserInfo from(UserModel userModel) {
+        return new UserInfo(
+                userModel.getUserId(),
+                userModel.getEmail(),
+                userModel.getBirthDate(),
+                userModel.getGender()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -19,9 +19,10 @@ public class PointEntity extends BaseEntity {
     private String userId;
     private Long amount;
 
-    public void chargeAmount(Long amount) {
+    void chargeAmount(Long amount) {
         if (amount <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "0이하의 포인트는 충전 할 수 없습니다.");
         }
+        this.amount += amount;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -16,4 +18,10 @@ public class PointEntity extends BaseEntity {
 
     private String userId;
     private Long amount;
+
+    public void chargeAmount(Long amount) {
+        if (amount <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "0이하의 포인트는 충전 할 수 없습니다.");
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "point")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointEntity extends BaseEntity {
+
+    private String userId;
+    private Long amount;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -3,6 +3,7 @@ package com.loopers.domain.point;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PointEntity extends BaseEntity {
 
+    @Column(unique = true)
     private String userId;
     private Long amount;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -6,5 +6,4 @@ public interface PointRepository {
 
     void save(PointEntity point);
 
-    void chargePoint(String userPoint, Long amount);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -5,4 +5,6 @@ public interface PointRepository {
     PointEntity findByUserId(String userId);
 
     void save(PointEntity point);
+
+    void chargePoint(String userPoint, Long amount);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.point;
+
+
+public interface PointRepository {
+    PointEntity findByUserId(String userId);
+
+    void save(PointEntity point);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.point;
 
+import com.loopers.application.point.PointInfo;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -13,17 +14,17 @@ public class PointService {
     private final PointRepository pointRepository;
 
     public PointEntity getPointByUserId(String userId){
-        PointEntity point = pointRepository.findByUserId(userId);
         return pointRepository.findByUserId(userId);
     }
 
     @Transactional
-    public PointEntity chargePoint(String userId, Long amount) {
-        PointEntity point = pointRepository.findByUserId(userId);
+    public PointEntity chargePoint(PointInfo pointInfo) {
+        PointEntity point = pointRepository.findByUserId(pointInfo.userId());
         if (point == null) {
           throw new CoreException(ErrorType.NOT_FOUND);
         }
-
-        return null;
+        point.chargeAmount(pointInfo.point());
+        pointRepository.save(point);
+        return point;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.point;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    public PointEntity getPointByUserId(String userId){
+        return pointRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.point;
 
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -10,6 +13,17 @@ public class PointService {
     private final PointRepository pointRepository;
 
     public PointEntity getPointByUserId(String userId){
+        PointEntity point = pointRepository.findByUserId(userId);
         return pointRepository.findByUserId(userId);
+    }
+
+    @Transactional
+    public PointEntity chargePoint(String userId, Long amount) {
+        PointEntity point = pointRepository.findByUserId(userId);
+        if (point == null) {
+          throw new CoreException(ErrorType.NOT_FOUND);
+        }
+
+        return null;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserModel.java
@@ -1,0 +1,89 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
+
+import static com.loopers.support.error.ErrorType.BAD_REQUEST;
+
+@Entity
+@Table(name = "users")
+public class UserModel extends BaseEntity {
+
+    private String userId;
+    private String gender;
+    private String email;
+    private String birthDate;
+
+    public UserModel(String userId, String email, String birthDate, String gender){
+        if (userId == null || userId.isBlank() || userId.length() > 10 || containsSpecialChar(userId)) {
+            throw new CoreException(BAD_REQUEST, "영문 및 숫자 10자 이내로 입력해 주세요.");
+        }
+        if (gender == null || gender.isBlank()){
+            throw new CoreException(BAD_REQUEST, "성별은 필수 값 입니다.");
+        }
+        if (!isEmail(email)){
+            throw new CoreException(BAD_REQUEST, "이메일 형식이 올바르지 않습니다.");
+        }
+
+        if (!isValidBirthDate(birthDate)){
+            throw new CoreException(BAD_REQUEST, "생년월일 형식에 맞지 않습니다.");
+        }
+
+    }
+
+    public UserModel() {
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getBirthDate() {
+        return birthDate;
+    }
+
+    private boolean isValidBirthDate(String birthDate) {
+        String pattern = "yyyy-MM-dd";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        try {
+            LocalDate.parse(birthDate, formatter);
+
+        }catch (DateTimeParseException parseException){
+            return false;
+        }
+        return true;
+    }
+
+    public boolean containsSpecialChar(String str){
+        for (char c: str.toCharArray()) {
+            if (!Character.isLetterOrDigit(c)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isEmail(String email){
+        String emailRegex = "^(.+)@(\\S+)$";
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        return Pattern.compile(emailRegex).matcher(email).matches();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserModel.java
@@ -22,7 +22,7 @@ public class UserModel extends BaseEntity {
     private String birthDate;
 
     public UserModel(String userId, String email, String birthDate, String gender){
-        if (userId == null || userId.isBlank() || userId.length() > 10 || containsSpecialChar(userId)) {
+        if (!isValidUserId(userId)) {
             throw new CoreException(BAD_REQUEST, "영문 및 숫자 10자 이내로 입력해 주세요.");
         }
         if (gender == null || gender.isBlank()){
@@ -35,6 +35,11 @@ public class UserModel extends BaseEntity {
         if (!isValidBirthDate(birthDate)){
             throw new CoreException(BAD_REQUEST, "생년월일 형식에 맞지 않습니다.");
         }
+
+        this.userId = userId;
+        this.email = email;
+        this.birthDate = birthDate;
+        this.gender = gender;
 
     }
 
@@ -55,6 +60,11 @@ public class UserModel extends BaseEntity {
 
     public String getBirthDate() {
         return birthDate;
+    }
+
+    private boolean isValidUserId(String userId){
+        String userIdRegex = "^[a-zA-Z0-9]{1,10}$";
+        return userId != null && userId.matches(userIdRegex);
     }
 
     private boolean isValidBirthDate(String birthDate) {
@@ -79,7 +89,7 @@ public class UserModel extends BaseEntity {
     }
 
     public boolean isEmail(String email){
-        String emailRegex = "^(.+)@(\\S+)$";
+        String emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
         if (email == null || email.isBlank()) {
             return false;
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.user;
+
+public interface UserRepository {
+   void save(UserModel userModel);
+
+    UserModel findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void signUp(UserModel userModel){
+        if (findByUserId(userModel.getUserId()) != null){
+            throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 ID 입니다.");
+        }
+        userRepository.save(userModel);
+    }
+
+    @Transactional(readOnly = true)
+    public UserModel findByUserId(String userId){
+        return userRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.PointEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointJpaRepository extends JpaRepository<PointEntity, Long> {
+    PointEntity findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -21,4 +21,9 @@ public class PointRepositoryImpl implements PointRepository {
         pointJpaRepository.save(point);
     }
 
+    @Override
+    public void chargePoint(String userPoint, Long amount) {
+
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointRepositoryImpl implements PointRepository {
+    private final PointJpaRepository pointJpaRepository;
+
+
+    @Override
+    public PointEntity findByUserId(String userId) {
+        return pointJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public void save(PointEntity point) {
+        pointJpaRepository.save(point);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -21,9 +21,5 @@ public class PointRepositoryImpl implements PointRepository {
         pointJpaRepository.save(point);
     }
 
-    @Override
-    public void chargePoint(String userPoint, Long amount) {
-
-    }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserModel, Long> {
+    UserModel findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository userJpaRepository;
+
+    public void save(UserModel userModel) {};
+
+    public UserModel findByUserId(String userId){
+        return userJpaRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Component;
 public class UserRepositoryImpl implements UserRepository {
     private final UserJpaRepository userJpaRepository;
 
-    public void save(UserModel userModel) {};
+    public void save(UserModel userModel) {
+        userJpaRepository.save(userModel);
+    };
 
     public UserModel findByUserId(String userId){
         return userJpaRepository.findByUserId(userId);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,16 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "포인트 V1 API", description = "포인트 API")
+public interface PointV1ApiSpec {
+
+    @Operation(
+            summary = "포인트 조회",
+            description = "회원 ID로 포인트 조회"
+
+    )
+    ApiResponse<PointV1Dto.PointResponse> getPoint(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -13,4 +13,12 @@ public interface PointV1ApiSpec {
 
     )
     ApiResponse<PointV1Dto.PointResponse> getPoint(String userId);
+
+
+    @Operation(
+            summary = "포인트 충전",
+            description = "회원 포인트 충전"
+
+    )
+    ApiResponse<PointV1Dto.PointResponse> chargePoint(String userId, PointV1Dto.PointChargeRequest request);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/points")
+@RequiredArgsConstructor
+public class PointV1Controller implements PointV1ApiSpec {
+
+    private final PointFacade pointFacade;
+
+    @Override
+    @GetMapping
+    public ApiResponse<PointV1Dto.PointResponse> getPoint(@RequestHeader(name = "X-USER-ID", required = false) String userId)
+    {
+
+        PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(pointFacade.getPoint(userId));
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,12 +1,10 @@
 package com.loopers.interfaces.api.point;
 
 import com.loopers.application.point.PointFacade;
+import com.loopers.application.point.PointInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/points")
@@ -21,6 +19,14 @@ public class PointV1Controller implements PointV1ApiSpec {
     {
 
         PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(pointFacade.getPoint(userId));
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @PostMapping("/charge")
+    public ApiResponse<PointV1Dto.PointResponse> chargePoint(@RequestHeader(name = "X-USER-ID") String userId, @RequestBody PointV1Dto.PointChargeRequest request) {
+        PointInfo pointInfo = pointFacade.chargePoint(PointInfo.to(userId, request));
+        PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(pointInfo);
         return ApiResponse.success(response);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -8,4 +8,10 @@ public class PointV1Dto {
             return new PointResponse(pointInfo.point());
         }
     }
+
+    public record PointChargeRequest(Long point) {
+        public static PointChargeRequest from(Long point) {
+            return new PointChargeRequest(point);
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointInfo;
+
+public class PointV1Dto {
+    public record PointResponse(Long point) {
+        public static PointResponse from(PointInfo pointInfo) {
+            return new PointResponse(pointInfo.point());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "User API 입니다.")
+public interface UserV1ApiSpec {
+
+    @Operation(
+        summary = "회원 가입",
+        description = "ID, 이메일, 생년월일, 성별"
+    )
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+        @Schema(name = "회원가입", description = "회원가입")
+        UserV1Dto.UserRequest userRequest
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -10,10 +10,19 @@ public interface UserV1ApiSpec {
 
     @Operation(
         summary = "회원 가입",
-        description = "ID, 이메일, 생년월일, 성별"
+        description = "ID, 이메일, 생년월일, 성별 정보로 회원 가입"
     )
     ApiResponse<UserV1Dto.UserResponse> signUp(
-        @Schema(name = "회원가입", description = "회원가입")
+        @Schema(name = "회원가입 요청 Dto", description = "회원가입 요청 Dto")
         UserV1Dto.UserRequest userRequest
+    );
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "회원의 ID로 회원 정보 조회"
+    )
+    ApiResponse<UserV1Dto.UserResponse> myProfile(
+            @Schema(name = "회원의 ID", description = "조회 할 회원의 ID")
+            String userId
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -6,16 +6,19 @@ import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RestController("/api/v1")
+@RestController
+@RequestMapping("/api/v1/users")
 @Component
 public class UserV1Controller implements UserV1ApiSpec{
     private final UserFacade userFacade;
 
-    @PostMapping("users")
-    public ApiResponse<UserV1Dto.UserResponse> signUp(UserV1Dto.UserRequest userRequest) {
+    @PostMapping
+    public ApiResponse<UserV1Dto.UserResponse> signUp(@RequestBody UserV1Dto.UserRequest userRequest) {
         userFacade.signUp(UserV1Dto.UserRequest.to(userRequest));
         UserInfo userInfo = userFacade.findByUserId(userRequest.userId());
         UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController("/api/v1")
+@Component
+public class UserV1Controller implements UserV1ApiSpec{
+    private final UserFacade userFacade;
+
+    @PostMapping("users")
+    public ApiResponse<UserV1Dto.UserResponse> signUp(UserV1Dto.UserRequest userRequest) {
+        userFacade.signUp(UserV1Dto.UserRequest.to(userRequest));
+        UserInfo userInfo = userFacade.findByUserId(userRequest.userId());
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -5,10 +5,7 @@ import com.loopers.application.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,6 +18,14 @@ public class UserV1Controller implements UserV1ApiSpec{
     public ApiResponse<UserV1Dto.UserResponse> signUp(@RequestBody UserV1Dto.UserRequest userRequest) {
         userFacade.signUp(UserV1Dto.UserRequest.to(userRequest));
         UserInfo userInfo = userFacade.findByUserId(userRequest.userId());
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @GetMapping("/{userId}")
+    public ApiResponse<UserV1Dto.UserResponse> myProfile(@PathVariable String userId) {
+        UserInfo userInfo = userFacade.findByUserId(userId);
         UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
         return ApiResponse.success(response);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,27 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserInfo;
+
+public class UserV1Dto {
+    public record UserResponse(String userId, String email, String brithDate, String gender) {
+        public static UserResponse from(UserInfo info) {
+            return new UserResponse(
+                    info.userId(),
+                    info.email(),
+                    info.birthDate(),
+                    info.gender()
+            );
+        }
+    }
+
+    public record UserRequest(String userId, String email, String birthdate, String gender){
+        public static UserInfo to(UserRequest request){
+            return new UserInfo(
+                    request.userId(),
+                    request.email(),
+                    request.birthdate(),
+                    request.gender()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointEntityTest.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.point;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+class PointEntityTest {
+
+    @DisplayName("포인트 충전 테스트")
+    @Nested
+    class PointChargeTest {
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, 0L, -333333L})
+        void failsPointCharge_whenAmountIsNotPositive(Long amount){
+            // arrange
+            PointEntity point = new PointEntity("userId", 0L);
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                point.chargeAmount(amount);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.point;
 
+import com.loopers.application.point.PointInfo;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -15,11 +16,6 @@ import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
 class PointServiceIntegrationTest {
-
-    /**
-     * - [ ]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
-     * - [ ]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
-     */
 
     @Autowired
     private PointService pointService;
@@ -88,7 +84,7 @@ class PointServiceIntegrationTest {
 
                 // act
                 CoreException result = assertThrows(CoreException.class, () -> {
-                    pointService.chargePoint(nonExistUserId, 1000L);
+                    pointService.chargePoint(new PointInfo(nonExistUserId, 1000L));
                 });
 
                 // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,14 +1,17 @@
 package com.loopers.domain.point;
 
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 class PointServiceIntegrationTest {
@@ -21,7 +24,7 @@ class PointServiceIntegrationTest {
     @Autowired
     private PointService pointService;
 
-    @Autowired
+    @MockitoSpyBean
     private PointRepository pointRepository;
 
     @Autowired
@@ -70,6 +73,30 @@ class PointServiceIntegrationTest {
             assertThat(point).isNull();
         }
 
+
+        @DisplayName("포인트 충전")
+        @Nested
+        class chargePoint{
+
+            @DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
+            @Test
+            void failsChargePoint_when(){
+
+                //arrange
+                String nonExistUserId = "nonExistUserId";
+                doReturn(null).when(pointRepository).findByUserId(nonExistUserId);
+
+                // act
+                CoreException result = assertThrows(CoreException.class, () -> {
+                    pointService.chargePoint(nonExistUserId, 1000L);
+                });
+
+                // assert
+                assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+
+            }
+
+        }
 
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.loopers.domain.point;
+
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class PointServiceIntegrationTest {
+
+    /**
+     * - [ ]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
+     * - [ ]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
+     */
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @BeforeEach
+    void setUp() {
+        pointRepository.save(new PointEntity("shwlsdn", 1000L));
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("포인트 조회")
+    @Nested
+    class get {
+
+        @DisplayName("해당 ID의 회원이 존재할 경우, 보유 포인트가 반환 된다.")
+        @Test
+        void returnPoint_whenUserExists() {
+            // arrange
+            String userId = "shwlsdn";
+            // act
+            PointEntity point = pointService.getPointByUserId(userId);
+
+            // assert
+            assertAll(
+                    () -> assertThat(point.getId()).isNotNull(),
+                    () -> assertThat(point.getUserId()).isEqualTo(userId),
+                    () -> assertThat(point.getAmount()).isNotNull()
+            );
+        }
+
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnNull_whenUserNotExists() {
+            // arrange
+            String userId = "shassdsadwlsdn";
+            // act
+            PointEntity point = pointService.getPointByUserId(userId);
+
+            // assert
+            assertThat(point).isNull();
+        }
+
+
+    }
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -3,7 +3,6 @@ package com.loopers.domain.point;
 import com.loopers.application.point.PointInfo;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class PointServiceIntegrationTest {
@@ -23,19 +23,6 @@ class PointServiceIntegrationTest {
     @MockitoSpyBean
     private PointRepository pointRepository;
 
-    @Autowired
-    private DatabaseCleanUp databaseCleanUp;
-
-    @BeforeEach
-    void setUp() {
-        pointRepository.save(new PointEntity("shwlsdn", 1000L));
-    }
-
-    @AfterEach
-    void tearDown() {
-        databaseCleanUp.truncateAllTables();
-    }
-
     @DisplayName("포인트 조회")
     @Nested
     class get {
@@ -45,8 +32,10 @@ class PointServiceIntegrationTest {
         void returnPoint_whenUserExists() {
             // arrange
             String userId = "shwlsdn";
+            PointEntity pointEntity = new PointEntity(userId, 1000L);
+            when(pointRepository.findByUserId(userId)).thenReturn(pointEntity);
             // act
-            PointEntity point = pointService.getPointByUserId(userId);
+            PointEntity point = pointService.getPointByUserId(pointEntity.getUserId());
 
             // assert
             assertAll(
@@ -62,6 +51,8 @@ class PointServiceIntegrationTest {
         void returnNull_whenUserNotExists() {
             // arrange
             String userId = "shassdsadwlsdn";
+            doReturn(null).when(pointRepository).findByUserId(userId);
+
             // act
             PointEntity point = pointService.getPointByUserId(userId);
 
@@ -76,10 +67,10 @@ class PointServiceIntegrationTest {
 
             @DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
             @Test
-            void failsChargePoint_when(){
+            void failsChargePoint_whenNonExistUserId(){
 
                 //arrange
-                String nonExistUserId = "nonExistUserId";
+                String nonExistUserId = "shwlsdn";
                 doReturn(null).when(pointRepository).findByUserId(nonExistUserId);
 
                 // act

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserModelTest.java
@@ -1,0 +1,113 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UserModelTest {
+
+    @DisplayName("유저 모델 생성")
+    @Nested
+    class Create {
+
+        @DisplayName("ID가 영문 및 숫자 10자 이내, 이메일이 xx@yy.zz, 생년월일이 yyyy-MM-dd, 성별이 비어있지 않은 경우 객체가 정상적으로 생성된다.")
+        @Test
+        void createsUserModel_whenAllFormatValidation(){
+            String userId = "shwlsdn1";
+            String email = "shwlsdn1@gmail.com";
+            String birthDate = "1994-08-19";
+            String gender = "M";
+            UserModel userModel = new UserModel(userId, email, birthDate, gender);
+            assertAll(
+                    () -> assertThat(userModel.getId()).isNotNull(),
+                    () -> assertThat(userModel.getUserId()).isEqualTo(userId),
+                    () -> assertThat(userModel.getEmail()).isEqualTo(email),
+                    () -> assertThat(userModel.getBirthDate()).isEqualTo(birthDate),
+                    () -> assertThat(userModel.getGender()).isEqualTo(gender)
+            );
+        }
+
+
+
+        @DisplayName("ID가 한글일 경우, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwsBadRequestException_whenUserIdContainsKoreanCharacters(){
+            String email = "shwlsdn1@gmail.com";
+            String birthDate = "1994-08-19";
+            String gender = "M";
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new UserModel("aa노진우1", email, birthDate, gender);
+
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("ID가 10자를 넘는 경우, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwsBadRequestException_whenIdLengthExceedsTenCharacters(){
+            String email = "shwlsdn1@gmail.com";
+            String birthDate = "1994-08-19";
+            String gender = "M";
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new UserModel("123456789aa", email, birthDate, gender);
+
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("email이 xx@yy.zz 형식에 맞지 않는 경우, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwsBadRequestException_whenEmailFormatIsInvalid(){
+            String userId = "shwlsdn1";
+            String birthDate = "1994-08-19";
+            String gender = "M";
+            CoreException resultContainKoreanCharacter = assertThrows(CoreException.class, () -> {
+                new UserModel(userId, "노진우@aa.cc", birthDate, gender);
+            });
+            CoreException resultEmailBlank = assertThrows(CoreException.class, () -> {
+                new UserModel(userId, " ", birthDate, gender);
+            });
+            CoreException resultInvalidEmail= assertThrows(CoreException.class, () -> {
+                new UserModel(userId, "abce@aa", birthDate, gender);
+            });
+
+            assertAll(
+                    () -> assertThat(resultContainKoreanCharacter.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST),
+                    () -> assertThat(resultEmailBlank.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST),
+                    () -> assertThat(resultInvalidEmail.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST)
+
+            );
+        }
+
+        @DisplayName("생년월일이 yyyy-MM-dd 형식에 맞지 않는 경우, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwsBadRequestException_whenBirthDateFormatIsInvalid(){
+            String userId = "shwlsdn1";
+            String email = "shwlsdn1@gmail.com";
+            String gender = "M";
+
+            CoreException resultEmailBlank = assertThrows(CoreException.class, () -> {
+                new UserModel(userId, email, " ", gender);
+            });
+            CoreException resultDateFormat_yyyyMMdd= assertThrows(CoreException.class, () -> {
+                new UserModel(userId, email, "19940819", gender);
+            });
+
+            assertAll(
+                    () -> assertThat(resultEmailBlank.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST),
+                    () -> assertThat(resultDateFormat_yyyyMMdd.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST)
+            );
+        }
+
+    }
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.loopers.domain.user;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class UserServiceIntegrationTest {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("회원 가입")
+    @Nested
+    class save {
+
+        @DisplayName("회원 저장")
+        @Test
+        void signUpUser(){
+            // arrange
+            UserModel userModel = new UserModel("shwlsdn", "shwlsdn@co.kr", "1994-08-19", "M");
+
+            //act
+            userService.signUp(userModel);
+            UserModel result = userJpaRepository.findByUserId(userModel.getUserId());
+
+            // assert
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.getId()).isNotNull(),
+                    () -> assertThat(result.getUserId()).isEqualTo(userModel.getUserId()),
+                    () -> assertThat(result.getEmail()).isEqualTo(userModel.getEmail()),
+                    () -> assertThat(result.getBirthDate()).isEqualTo(userModel.getBirthDate()),
+                    () -> assertThat(result.getGender()).isEqualTo(userModel.getGender())
+            );
+
+        }
+
+        @DisplayName("이미 가입된 ID로 회원가입 시도 시, 실패한다.")
+        @Test
+        void failSignUp_whenUserIdAlreadyExists(){
+            // arrange
+            UserModel userModel = new UserModel("shwlsdn", "shwlsdn@co.kr", "1994-08-19", "M");
+            UserModel userModel2 = new UserModel("shwlsdn", "shwlsdn@co.kr", "1994-08-19", "M");
+            userService.signUp(userModel);
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                userService.signUp(userModel2);
+            });
+
+
+            // assert
+            assertThat(exception.getCustomMessage()).contains("이미 존재하는 ID");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -74,4 +74,43 @@ class UserServiceIntegrationTest {
             assertThat(exception.getCustomMessage()).contains("이미 존재하는 ID");
         }
     }
+
+    @DisplayName("내 정보 조회")
+    @Nested
+    class get {
+        @DisplayName("해당 ID의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnUserInfo_whenExistUserId(){
+            // arrange
+            UserModel userModel = new UserModel("shwlsdn", "shwlsdn123@asd.cd", "1994-08-19", "M");
+            userJpaRepository.save(userModel);
+
+            // act
+            UserModel result = userService.findByUserId("shwlsdn");
+
+            // assert
+            assertAll(
+                    () -> assertThat(result.getUserId()).isEqualTo(userModel.getUserId()),
+                    () -> assertThat(result.getEmail()).isEqualTo(userModel.getEmail()),
+                    () -> assertThat(result.getBirthDate()).isEqualTo(userModel.getBirthDate()),
+                    () -> assertThat(result.getGender()).isEqualTo(userModel.getGender())
+
+            );
+        }
+    }
+
+    @DisplayName("해당 ID의 회원이 존재하지 않을 경우, null을 반환 한다.")
+    @Test
+    void returnNull_whenNotExistUserId(){
+        // arrange
+        String userId = "abcedfg";
+
+        // act
+        UserModel result = userService.findByUserId(userId);
+
+        // assert
+        assertThat(result).isNull();
+    }
+
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -9,17 +9,20 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 class UserServiceIntegrationTest {
     @Autowired
     private UserService userService;
 
-    @Autowired
+    @MockitoSpyBean
     private UserJpaRepository userJpaRepository;
 
     @Autowired
@@ -42,18 +45,9 @@ class UserServiceIntegrationTest {
 
             //act
             userService.signUp(userModel);
-            UserModel result = userJpaRepository.findByUserId(userModel.getUserId());
 
             // assert
-            assertAll(
-                    () -> assertThat(result).isNotNull(),
-                    () -> assertThat(result.getId()).isNotNull(),
-                    () -> assertThat(result.getUserId()).isEqualTo(userModel.getUserId()),
-                    () -> assertThat(result.getEmail()).isEqualTo(userModel.getEmail()),
-                    () -> assertThat(result.getBirthDate()).isEqualTo(userModel.getBirthDate()),
-                    () -> assertThat(result.getGender()).isEqualTo(userModel.getGender())
-            );
-
+            verify(userJpaRepository, times(1)).save(userModel);
         }
 
         @DisplayName("이미 가입된 ID로 회원가입 시도 시, 실패한다.")

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1ApiE2ETest.java
@@ -22,10 +22,6 @@ public class PointV1ApiE2ETest {
     private static final String ENDPOINT = "/api/v1/points";
     private static final String HEADER = "X-USER-ID";
 
-    /**
-     * - [ ]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
-     * - [ ]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
-     */
 
     @Autowired
     private PointRepository pointRepository;
@@ -75,7 +71,7 @@ public class PointV1ApiE2ETest {
 
         @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.")
         @Test
-        void throwsBadRequest_whenUserIdHeaderNotPresent(){
+        void throwsBadRequest_whenUserIdHeaderNotPresent() {
             // arrange
             HttpHeaders httpHeaders = null;
 
@@ -91,6 +87,52 @@ public class PointV1ApiE2ETest {
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
                     () -> assertThat(response.getBody().data()).isNull()
             );
+
+        }
+
+        @DisplayName("POST /api/v1/points/charge")
+        @Nested
+        class chargePoint {
+
+            @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+            @Test
+            void returnTotalPoint_whenChargePointForExistingUser() {
+                // pointRepository.findByUserId에서 "shwlsdn"라는 유저를 리턴 하는 테스트 객체 만든 후 테스트 진행
+                // arrange
+                HttpHeaders httpHeaders = new HttpHeaders();
+                httpHeaders.add(HEADER, "shwlsdn");
+                PointV1Dto.PointChargeRequest pointChargeRequest = new PointV1Dto.PointChargeRequest(1000L);
+
+
+                // act
+                ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {
+                };
+                ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response = testRestTemplate.exchange(ENDPOINT + "/charge", HttpMethod.POST, new HttpEntity<>(pointChargeRequest, httpHeaders), responseType);
+
+                assertAll(
+                        () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                        () -> assertThat(response.getBody().data().point()).isEqualTo(2000L)
+                );
+            }
+
+            @DisplayName("존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.")
+            @Test
+            void returnNotFound_whenChargePointForNonExistingUser() {
+                PointV1Dto.PointChargeRequest pointChargeRequest = new PointV1Dto.PointChargeRequest(1000L);
+                HttpHeaders httpHeaders = new HttpHeaders();
+                httpHeaders.add(HEADER, "bbbbbb");
+
+
+                ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {
+                };
+                ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response = testRestTemplate.exchange(ENDPOINT + "/charge", HttpMethod.POST, new HttpEntity<>(pointChargeRequest, httpHeaders), responseType);
+
+                assertAll(
+                        () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                        () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND),
+                        () -> assertThat(response.getBody().data()).isNull()
+                );
+            }
 
         }
 

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1ApiE2ETest.java
@@ -1,0 +1,98 @@
+package com.loopers.interfaces.api;
+
+
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.interfaces.api.point.PointV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PointV1ApiE2ETest {
+
+    private static final String ENDPOINT = "/api/v1/points";
+    private static final String HEADER = "X-USER-ID";
+
+    /**
+     * - [ ]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
+     * - [ ]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
+     */
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+
+    @BeforeEach
+    void setUp() {
+        pointRepository.save(new PointEntity("shwlsdn", 1000L));
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("Get /api/v1/points")
+    @Nested
+    class getPoint {
+
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsPoint_whenSuccess() {
+            // arrange
+
+            String userId = "shwlsdn";
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.add(HEADER, userId);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response = testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody().data().point()).isEqualTo(1000L)
+            );
+
+        }
+
+        @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void throwsBadRequest_whenUserIdHeaderNotPresent(){
+            // arrange
+            HttpHeaders httpHeaders = null;
+
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response = testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                    () -> assertThat(response.getBody().data()).isNull()
+            );
+
+        }
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
@@ -1,6 +1,8 @@
 package com.loopers.interfaces.api;
 
 
+import com.loopers.domain.user.UserModel;
+import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -16,6 +18,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,16 +28,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class UserV1ApiE2ETest {
 
     private static final String ENDPOINT = "/api/v1/users";
+    private static final Function<String, String> ENDPOINT_GET = userId -> "/api/v1/users/" + userId;
 
     private final TestRestTemplate testRestTemplate;
+    private final UserJpaRepository userJpaRepository;
     private final DatabaseCleanUp databaseCleanUp;
 
     @Autowired
     public UserV1ApiE2ETest(
             TestRestTemplate testRestTemplate,
+            UserJpaRepository userJpaRepository,
             DatabaseCleanUp databaseCleanUp
     ) {
         this.testRestTemplate = testRestTemplate;
+        this.userJpaRepository = userJpaRepository;
         this.databaseCleanUp = databaseCleanUp;
     }
 
@@ -44,7 +52,7 @@ class UserV1ApiE2ETest {
 
     @DisplayName("POST /api/v1/users")
     @Nested
-    class save{
+    class save {
         @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
         @Test
         void returnUserInfo_whenSignUpSuccessful() {
@@ -52,7 +60,8 @@ class UserV1ApiE2ETest {
             UserV1Dto.UserRequest userRequest = new UserV1Dto.UserRequest("shwlsdn", "shwlsdn@go.kr", "1994-08-19", "M");
 
             // act
-            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(userRequest), responseType);
 
             // assert
@@ -69,12 +78,13 @@ class UserV1ApiE2ETest {
 
         @DisplayName("회원 가입시 성별이 없을 경우, 400 Bad Request 응답을 받는다.")
         @Test
-        void throwsBadRequest_whenGenderIsNotProvided(){
+        void throwsBadRequest_whenGenderIsNotProvided() {
             // arrange
             UserV1Dto.UserRequest userRequest = new UserV1Dto.UserRequest("shwlsdn", "shwlsdn@go.kr", "1994-08-19", "");
 
             // act
-            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(userRequest), responseType);
 
             assertAll(
@@ -84,8 +94,55 @@ class UserV1ApiE2ETest {
 
 
         }
-
-
     }
+
+    @DisplayName("내 정보 조회")
+    @Nested
+    class get {
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환 받는다.")
+        @Test
+        void returnUserInfo_whenUserExists() {
+            // arrange
+            UserModel userModel = new UserModel("shwlsdn", "shwlsdn@go.kr", "1994-08-19", "M");
+            userJpaRepository.save(userModel);
+            String requestUrl = ENDPOINT_GET.apply("shwlsdn");
+
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(null), responseType);
+
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody().data().userId()).isEqualTo(userModel.getUserId()),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(userModel.getEmail()),
+                    () -> assertThat(response.getBody().data().brithDate()).isEqualTo(userModel.getBirthDate()),
+                    () -> assertThat(response.getBody().data().gender()).isEqualTo(userModel.getGender())
+
+            );
+        }
+
+        @DisplayName("존재하지 않는 ID로 조회할 경우, 404 Not Found 응답을 받는다")
+        @Test
+        void throwsNotFound_whenNotExistUserId() {
+            // arrange
+            UserModel userModel = new UserModel("shwlsdn", "shwlsdn@go.kr", "1994-08-19", "M");
+            userJpaRepository.save(userModel);
+            String requestUrl = ENDPOINT_GET.apply("ㄴㄴㄴㄴ");
+
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(null), responseType);
+
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
+
+
+        }
+    }
+
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
@@ -1,0 +1,91 @@
+package com.loopers.interfaces.api;
+
+
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UserV1ApiE2ETest {
+
+    private static final String ENDPOINT = "/api/v1/users";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public UserV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class save{
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnUserInfo_whenSignUpSuccessful() {
+            // arrange
+            UserV1Dto.UserRequest userRequest = new UserV1Dto.UserRequest("shwlsdn", "shwlsdn@go.kr", "1994-08-19", "M");
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(userRequest), responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody().data().userId()).isEqualTo(userRequest.userId()),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(userRequest.email()),
+                    () -> assertThat(response.getBody().data().brithDate()).isEqualTo(userRequest.birthdate()),
+                    () -> assertThat(response.getBody().data().gender()).isEqualTo(userRequest.gender())
+
+            );
+
+        }
+
+        @DisplayName("회원 가입시 성별이 없을 경우, 400 Bad Request 응답을 받는다.")
+        @Test
+        void throwsBadRequest_whenGenderIsNotProvided(){
+            // arrange
+            UserV1Dto.UserRequest userRequest = new UserV1Dto.UserRequest("shwlsdn", "shwlsdn@go.kr", "1994-08-19", "");
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(userRequest), responseType);
+
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
+            );
+
+
+        }
+
+
+    }
+
+}

--- a/modules/jpa/build.gradle.kts
+++ b/modules/jpa/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     // querydsl
     api("com.querydsl:querydsl-jpa::jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     // jdbc-mysql
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/modules/jpa/src/testFixtures/java/com/loopers/testcontainers/MySqlTestContainersConfig.java
+++ b/modules/jpa/src/testFixtures/java/com/loopers/testcontainers/MySqlTestContainersConfig.java
@@ -10,7 +10,7 @@ public class MySqlTestContainersConfig {
     private static final MySQLContainer<?> mySqlContainer;
 
     static {
-        mySqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:5.7"))
+        mySqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
             .withDatabaseName("loopers")
             .withUsername("test")
             .withPassword("test")


### PR DESCRIPTION
## 📌 Summary
   - 어떤 기능/이슈를 해결했는지 요약해주세요.
    @BeforeEach, @AfterEach를 통한 테스트에서 Spy + Stub 테스트로 일관성을 유지 하였습니다.


## 💬 Review Points

    - 고민했던 설계 포인트나 로직
        회원과 포인트간 JPA 연관관계를 맺고 그래프 탐색이 필수 인건지 궁금 합니다.
        실무에서 JPA를 사용해본적이 없고 JPA에 대한 이해도가 부족한 상황 입니다. 
        생각 없이 우선  포인트에서 userId로만 식별 할 수 있게 설계 했는데요. (fk x)
        실무에서 JPA 사용시 연관관계를 맺는게 선호 되는지, MSA 구조에서 서로 다른 DB에서 관리 된다면 어떻게 되는지 짧게나마 알고 싶습니다. 사실 1주차 테스트와는 크게 상관이 없는 것 같긴해요.... 테스트나 더 공부 하겠습니다. 
    - 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
        A. 저장 테스트시 저장 후 조회 하는 케이스 vs B. Spy 테스트로 호출 여부 테스트
       저장에 대한 기능이라고 생각해  A -> B 방식으로 리팩토링 했습니다. A방식으로 구현 하는건 어떻게 생각 하시나요?


## ✅ Checklist
 
    - [ ] facade계층 테스트
    - [ ] TODO - 회원 성별 String -> Enum 변경


감사합니다.